### PR TITLE
Add ITS device profiles

### DIFF
--- a/vendors/its/devices/sensor-ff.toml
+++ b/vendors/its/devices/sensor-ff.toml
@@ -1,0 +1,10 @@
+[device]
+id = "67993019-f108-4253-bf9f-252dfbe78fbc"
+name = "sensor FF"
+description = "sensor node FF"
+
+[[device.firmware]]
+version = "1.0.0"
+profiles = [
+    "sensor-ff-as923-1_0_3-class-a.toml",
+]

--- a/vendors/its/devices/standard.toml
+++ b/vendors/its/devices/standard.toml
@@ -1,0 +1,10 @@
+[device]
+id = "9aee88e7-7b8b-4b69-b3d5-3c335e220620"
+name = "standard"
+description = "standard device for IoT"
+
+[[device.firmware]]
+version = "1.0.0"
+profiles = [
+    "standard-as923-1_0_3-class-c.toml",
+]

--- a/vendors/its/profiles/sensor-ff-as923-1_0_3-class-a.toml
+++ b/vendors/its/profiles/sensor-ff-as923-1_0_3-class-a.toml
@@ -1,0 +1,25 @@
+[profile]
+id = "f56616cf-e2f5-4041-83c6-f8d2e5b39119"
+vendor_profile_id = 0
+region = "AS923"
+mac_version = "1.0.3"
+reg_params_revision = "RP002-1.0.3"
+supports_otaa = true
+supports_class_b = false
+supports_class_c = false
+max_eirp = 16
+
+[profile.abp]
+rx1_delay = 0
+rx1_dr_offset = 0
+rx2_dr = 0
+rx2_freq = 0
+
+[profile.class_b]
+timeout_secs = 0
+ping_slot_nb_k = 0
+ping_slot_dr = 0
+ping_slot_freq = 0
+
+[profile.class_c]
+timeout_secs = 0

--- a/vendors/its/profiles/standard-as923-1_0_3-class-c.toml
+++ b/vendors/its/profiles/standard-as923-1_0_3-class-c.toml
@@ -1,0 +1,25 @@
+[profile]
+id = "a612d761-07f7-490b-8349-e0253e1fa4e1"
+vendor_profile_id = 0
+region = "AS923"
+mac_version = "1.0.3"
+reg_params_revision = "RP002-1.0.3"
+supports_otaa = true
+supports_class_b = false
+supports_class_c = true
+max_eirp = 16
+
+[profile.abp]
+rx1_delay = 0
+rx1_dr_offset = 0
+rx2_dr = 0
+rx2_freq = 0
+
+[profile.class_b]
+timeout_secs = 0
+ping_slot_nb_k = 0
+ping_slot_dr = 0
+ping_slot_freq = 0
+
+[profile.class_c]
+timeout_secs = 120

--- a/vendors/its/vendor.toml
+++ b/vendors/its/vendor.toml
@@ -1,0 +1,9 @@
+[vendor]
+id = "2fa33e13-198f-421f-9e0e-bc3efa89b926"
+name = "ITS"
+vendor_id = 0
+ouis = []
+devices = [
+    "standard.toml",
+    "sensor-ff.toml",
+]


### PR DESCRIPTION
Adds ITS vendor device profiles for AS923 LoRaWAN 1.0.3 / RP002-1.0.3.

Included devices:
- standard: Class C, OTAA
- sensor FF: Class A, OTAA

Validation:
- docker run --rm -v <repo>:/chirpstack-device-profiles chirpstack/chirpstack-device-profiles:latest -p /chirpstack-device-profiles run-tests