### PR TITLE
Add Elsys EMS series device definitions and profiles

### DIFF
--- a/vendors/elsys/codecs/test_decode_elsys.json
+++ b/vendors/elsys/codecs/test_decode_elsys.json
@@ -134,5 +134,20 @@
         "occupancy": 2
       }
     }
+  },
+  {
+    "name": "Test decode EMS Lite payload",
+    "input": {
+      "fPort": 5,
+      "bytes": [1, 0, 215, 2, 45, 18, 1, 7, 14, 24]
+    },
+    "expected": {
+      "data": {
+        "temperature": 21.5,
+        "humidity": 45,
+        "waterleak": 1,
+        "vdd": 3608
+      }
+    }
   }
 ]

--- a/vendors/elsys/devices/ems-desk.toml
+++ b/vendors/elsys/devices/ems-desk.toml
@@ -1,0 +1,16 @@
+[device]
+id = "e6c7d8e9-0a1b-4234-c567-89abcdef0123"
+name = "EMS Desk"
+description = "Indoor desk occupancy sensor with temperature, humidity, and IR occupancy detection."
+
+[[device.firmware]]
+version = "1.0"
+profiles = [
+    "EU868-1_0_4.toml",
+    "US915-1_0_4.toml",
+]
+codec = "elsys.js"
+
+[device.metadata]
+product_url = "https://www.elsys.se/en/ems-desk/"
+documentation_url = "https://elsys.se/public/datasheets/EMS_Series_LoRa_Datasheet.pdf"

--- a/vendors/elsys/devices/ems-door.toml
+++ b/vendors/elsys/devices/ems-door.toml
@@ -1,0 +1,16 @@
+[device]
+id = "d5b6c7d8-9f0a-4123-b456-789abcdef012"
+name = "EMS Door"
+description = "Indoor door activity sensor with accelerometer and reed switch."
+
+[[device.firmware]]
+version = "1.0"
+profiles = [
+    "EU868-1_0_4.toml",
+    "US915-1_0_4.toml",
+]
+codec = "elsys.js"
+
+[device.metadata]
+product_url = "https://www.elsys.se/en/ems-door/"
+documentation_url = "https://elsys.se/public/datasheets/EMS_Series_LoRa_Datasheet.pdf"

--- a/vendors/elsys/devices/ems-lite.toml
+++ b/vendors/elsys/devices/ems-lite.toml
@@ -1,0 +1,16 @@
+[device]
+id = "a6b18c2d-94e5-4f67-b892-123456789a01"
+name = "EMS Lite"
+description = "Indoor climate and water leak sensor measuring temperature, humidity, and water leak detection."
+
+[[device.firmware]]
+version = "1.0"
+profiles = [
+    "EU868-1_0_4.toml",
+    "US915-1_0_4.toml",
+]
+codec = "elsys.js"
+
+[device.metadata]
+product_url = "https://www.elsys.se/en/ems-lite/"
+documentation_url = "https://elsys.se/public/datasheets/EMS_Series_LoRa_Datasheet.pdf"

--- a/vendors/elsys/devices/ems.toml
+++ b/vendors/elsys/devices/ems.toml
@@ -1,0 +1,16 @@
+[device]
+id = "c4a5b6d7-8e9f-4012-a345-6789abcdef01"
+name = "EMS"
+description = "Indoor multi-sensor with temperature, humidity, accelerometer, reed switch (door activity), and water leak detection."
+
+[[device.firmware]]
+version = "1.0"
+profiles = [
+    "EU868-1_0_4.toml",
+    "US915-1_0_4.toml",
+]
+codec = "elsys.js"
+
+[device.metadata]
+product_url = "https://www.elsys.se/en/ems/"
+documentation_url = "https://elsys.se/public/datasheets/EMS_Series_LoRa_Datasheet.pdf"

--- a/vendors/elsys/profiles/EU868-1_0_4.toml
+++ b/vendors/elsys/profiles/EU868-1_0_4.toml
@@ -1,0 +1,25 @@
+[profile]
+id = "d13fcde4-30bc-4671-99ce-ccaed062a62d"
+vendor_profile_id = 0
+region = "EU868"
+mac_version = "1.0.4"
+reg_params_revision = "RP002-1.0.3"
+supports_otaa = true
+supports_class_b = false
+supports_class_c = false
+max_eirp = 14
+
+[profile.abp]
+rx1_delay = 0
+rx1_dr_offset = 0
+rx2_dr = 0
+rx2_freq = 0
+
+[profile.class_b]
+timeout_secs = 0
+ping_slot_nb_k = 0
+ping_slot_dr = 0
+ping_slot_freq = 0
+
+[profile.class_c]
+timeout_secs = 0

--- a/vendors/elsys/profiles/US915-1_0_4.toml
+++ b/vendors/elsys/profiles/US915-1_0_4.toml
@@ -1,0 +1,25 @@
+[profile]
+id = "d678f9cf-95cb-4aa5-b73e-3117697c2a5c"
+vendor_profile_id = 0
+region = "US915"
+mac_version = "1.0.4"
+reg_params_revision = "RP002-1.0.3"
+supports_otaa = true
+supports_class_b = false
+supports_class_c = false
+max_eirp = 20
+
+[profile.abp]
+rx1_delay = 0
+rx1_dr_offset = 0
+rx2_dr = 0
+rx2_freq = 0
+
+[profile.class_b]
+timeout_secs = 0
+ping_slot_nb_k = 0
+ping_slot_dr = 0
+ping_slot_freq = 0
+
+[profile.class_c]
+timeout_secs = 0

--- a/vendors/elsys/vendor.toml
+++ b/vendors/elsys/vendor.toml
@@ -3,6 +3,10 @@ id = "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6"
 name = "Elsys"
 ouis = ["fc0fee"]
 devices = [
+    "ems-desk.toml",
+    "ems-door.toml",
+    "ems-lite.toml",
+    "ems.toml",
     "ers-eye-lna.toml",
     "elt-2-hp.toml",
 ]


### PR DESCRIPTION
This pull request brings the Elsys EMS Series devices:

- [EMS](https://www.elsys.se/en/lora-ems/)
- [EMS Lite](https://www.elsys.se/en/ems-lite/)
- [EMS Door](https://www.elsys.se/en/ems-door/)
- [EMS Desk](https://www.elsys.se/en/ems-desk/)

They all use the same [datasheet](https://elsys.se/public/datasheets/EMS_Series_LoRa_Datasheet.pdf) and the pull request includes the updated v1.0.4 the regional profiles matching the datasheet. The existing codec works and checked with one added test to decode an EMS playload matching the [official decoded values](https://www.elsys.se/en/elsys-payload/).